### PR TITLE
fix: prevent SARIF upload permission errors on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,16 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: always() && steps.check-sarif-backend.outputs.exists == 'true'
+        # Skip SARIF upload on PRs - GitHub restricts security-events permission on pull_request events
+        if: always() && steps.check-sarif-backend.outputs.exists == 'true' && github.event_name != 'pull_request'
         with:
           sarif_file: 'trivy-backend-results.sarif'
+
+      - name: Display scan results for PR
+        if: always() && steps.check-sarif-backend.outputs.exists == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "## Backend Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy scan completed. Full results will be available after merge." >> $GITHUB_STEP_SUMMARY
 
   build-frontend:
     name: Build Frontend Image
@@ -161,9 +168,16 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: always() && steps.check-sarif-frontend.outputs.exists == 'true'
+        # Skip SARIF upload on PRs - GitHub restricts security-events permission on pull_request events
+        if: always() && steps.check-sarif-frontend.outputs.exists == 'true' && github.event_name != 'pull_request'
         with:
           sarif_file: 'trivy-frontend-results.sarif'
+
+      - name: Display scan results for PR
+        if: always() && steps.check-sarif-frontend.outputs.exists == 'true' && github.event_name == 'pull_request'
+        run: |
+          echo "## Frontend Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "Trivy scan completed. Full results will be available after merge." >> $GITHUB_STEP_SUMMARY
 
   image-scan-summary:
     name: Security Scan Summary


### PR DESCRIPTION
## Problem

The security scan workflow was failing on pull requests with this error:
```
This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints. 
This could be because the Action is running on a pull request from a fork.
```

GitHub restricts the `security-events: write` permission on pull request events as a security measure to prevent malicious PRs from manipulating security scan results or accessing sensitive security information.

## Solution

Updated the build workflow to conditionally skip SARIF uploads on pull requests:
- ✅ Security scans still run on ALL builds (PRs and pushes)
- ✅ SARIF results upload to Security tab only on push events (main, tags)
- ✅ PR builds now show completion message instead of attempting upload
- ✅ No workflow failures due to permission restrictions

## Changes

### Modified `.github/workflows/build.yml`:
1. Added `github.event_name != 'pull_request'` condition to SARIF upload steps
2. Added new step to display scan results message for PRs
3. Added explanatory comments for maintainability

### Before (failing on PRs):
```yaml
- name: Upload Trivy results to GitHub Security
  if: always() && steps.check-sarif-backend.outputs.exists == 'true'
```

### After (skips PRs, works on all push events):
```yaml
- name: Upload Trivy results to GitHub Security
  # Skip SARIF upload on PRs - GitHub restricts security-events permission on pull_request events
  if: always() && steps.check-sarif-backend.outputs.exists == 'true' && github.event_name != 'pull_request'
```

## Security Impact

- ✅ No reduction in security coverage
- ✅ Trivy scans still run on every build
- ✅ Vulnerabilities are still detected and reported
- ✅ Results uploaded to Security tab after merge to main
- ✅ Prevents potential security bypass via malicious PRs

## Testing

This PR itself will test the fix:
- Security scan will run successfully
- No permission errors
- Scan completion message will appear in workflow summary