### PR TITLE
feat: enhance profile discovery and matching

### DIFF
--- a/backend/app/api/v1/matches.py
+++ b/backend/app/api/v1/matches.py
@@ -16,9 +16,13 @@ from app.schemas.match import (
     MatchResponse,
     MatchWithUserResponse
 )
-from app.schemas.user import UserPublicResponse
+from app.schemas.user import UserPublicResponse, ProfileDiscoverResponse
 from app.api.deps import get_current_user
 from app.services.matching import score_match, MIN_MATCH_SCORE
+
+# Active statuses: exclude from discover/recommendations. Dismissed/unmatched can reappear (matched_before).
+ACTIVE_MATCH_STATUSES = ("saved", "viewed", "intro_requested", "connected")
+PRIOR_MATCH_STATUSES = ("dismissed", "unmatched")
 
 router = APIRouter()
 
@@ -283,16 +287,17 @@ async def get_matches(
     return result
 
 
-@router.get("/recommendations", response_model=List[UserPublicResponse])
+@router.get("/recommendations", response_model=List[ProfileDiscoverResponse])
 async def get_match_recommendations(
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=50),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
-    """Get match recommendations - scored and ordered by match quality."""
+    """Get match recommendations - scored and ordered by match quality. Excludes only active matches; dismissed/unmatched can reappear with matched_before."""
     interacted_matches = db.query(Match.target_user_id).filter(
-        Match.user_id == current_user.id
+        Match.user_id == current_user.id,
+        Match.status.in_(ACTIVE_MATCH_STATUSES)
     ).all()
     interacted_ids = [match[0] for match in interacted_matches]
 
@@ -304,8 +309,6 @@ async def get_match_recommendations(
     if interacted_ids:
         query = query.filter(~User.id.in_(interacted_ids))
 
-    # Fetch a pool, score and filter, then paginate over the scored results so each
-    # page returns up to `limit` results from the ranked list (not from raw candidates).
     CANDIDATE_POOL_SIZE = 500
     candidates = query.order_by(User.created_at.desc()).limit(CANDIDATE_POOL_SIZE).all()
     scored: List[tuple[User, int]] = []
@@ -314,8 +317,28 @@ async def get_match_recommendations(
         if result["match_score"] >= MIN_MATCH_SCORE:
             scored.append((other, result["match_score"]))
     scored.sort(key=lambda x: x[1], reverse=True)
-    profiles = [u for u, _ in scored[skip : skip + limit]]
-    return profiles
+    page = [u for u, _ in scored[skip : skip + limit]]
+    if not page:
+        return []
+
+    # Users we had a prior (ended) match with - show "matched before"
+    prior = db.query(Match.target_user_id).filter(
+        Match.user_id == current_user.id,
+        Match.target_user_id.in_([u.id for u in page]),
+        Match.status.in_(PRIOR_MATCH_STATUSES)
+    ).all()
+    prior_ids = {m[0] for m in prior}
+    rec = db.query(Match.user_id).filter(
+        Match.target_user_id == current_user.id,
+        Match.user_id.in_([u.id for u in page]),
+        Match.status.in_(PRIOR_MATCH_STATUSES)
+    ).all()
+    prior_ids |= {m[0] for m in rec}
+
+    return [
+        ProfileDiscoverResponse(profile=UserPublicResponse.model_validate(u), matched_before=(u.id in prior_ids))
+        for u in page
+    ]
 
 
 @router.get("/{match_id}", response_model=MatchWithUserResponse)
@@ -387,6 +410,62 @@ async def get_match(
     }
 
     return MatchWithUserResponse(**match_dict)
+
+
+@router.post("/{match_id}/unmatch", status_code=status.HTTP_200_OK)
+async def unmatch(
+    match_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Unmatch a connected user - sets both sides to 'unmatched' so they can reappear in discover."""
+    try:
+        match_uuid = uuid.UUID(match_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid match ID"
+        )
+
+    match = db.query(Match).filter(Match.id == match_uuid).first()
+    if not match:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Match not found"
+        )
+    if match.user_id != current_user.id and match.target_user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to unmatch this connection"
+        )
+    if match.status != "connected":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only connected matches can be unmatched"
+        )
+
+    other_id = match.target_user_id if match.user_id == current_user.id else match.user_id
+
+    # Require both directions to exist so we never leave one side connected
+    forward = db.query(Match).filter(
+        Match.user_id == current_user.id,
+        Match.target_user_id == other_id
+    ).first()
+    reciprocal = db.query(Match).filter(
+        Match.user_id == other_id,
+        Match.target_user_id == current_user.id
+    ).first()
+    if not forward or not reciprocal:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot unmatch: reciprocal match record not found. Please contact support.",
+        )
+
+    for m in (forward, reciprocal):
+        m.status = "unmatched"  # type: ignore[assignment]
+        m.updated_at = datetime.utcnow()  # type: ignore[assignment]
+    db.commit()
+    return {"message": "Unmatched successfully", "match_id": match_id}
 
 
 @router.post("/{match_id}/intro", status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -7,40 +7,40 @@ import uuid
 from app.database import get_db
 from app.models.user import User
 from app.models.match import Match
-from app.schemas.user import UserPublicResponse
+from app.schemas.user import UserPublicResponse, ProfileDiscoverResponse
 from app.api.deps import get_current_user
 from app.services.matching import score_match, MIN_MATCH_SCORE
 
 router = APIRouter()
 
 
-@router.get("/discover", response_model=List[UserPublicResponse])
+# Exclude only active matches; dismissed/unmatched can reappear in discover (matched_before).
+ACTIVE_MATCH_STATUSES = ("saved", "viewed", "intro_requested", "connected")
+PRIOR_MATCH_STATUSES = ("dismissed", "unmatched")
+
+
+@router.get("/discover", response_model=List[ProfileDiscoverResponse])
 async def discover_profiles(
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=50),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
-    """Discover profiles to browse - excludes already saved/skipped/invited profiles"""
-    # Get IDs of profiles user has already interacted with
+    """Discover profiles - excludes only active matches (saved/invited/connected). Dismissed/unmatched can reappear with matched_before."""
     interacted_matches = db.query(Match.target_user_id).filter(
         Match.user_id == current_user.id,
-        Match.status.in_(["saved", "dismissed", "viewed", "intro_requested", "connected"])
+        Match.status.in_(ACTIVE_MATCH_STATUSES)
     ).all()
     interacted_ids = [match[0] for match in interacted_matches]
 
-    # Get profiles excluding current user and already interacted profiles
     query = db.query(User).filter(
         User.is_active,
         ~User.is_banned,
         User.id != current_user.id
     )
-    
     if interacted_ids:
         query = query.filter(~User.id.in_(interacted_ids))
 
-    # Fetch a pool, score and filter, then paginate over the scored results so each
-    # page returns up to `limit` results from the ranked list (not from raw candidates).
     CANDIDATE_POOL_SIZE = 500
     candidates = query.order_by(User.created_at.desc()).limit(CANDIDATE_POOL_SIZE).all()
     scored: List[tuple[User, int]] = []
@@ -49,8 +49,27 @@ async def discover_profiles(
         if result["match_score"] >= MIN_MATCH_SCORE:
             scored.append((other, result["match_score"]))
     scored.sort(key=lambda x: x[1], reverse=True)
-    profiles = [u for u, _ in scored[skip : skip + limit]]
-    return profiles
+    page = [u for u, _ in scored[skip : skip + limit]]
+    if not page:
+        return []
+
+    prior = db.query(Match.target_user_id).filter(
+        Match.user_id == current_user.id,
+        Match.target_user_id.in_([u.id for u in page]),
+        Match.status.in_(PRIOR_MATCH_STATUSES)
+    ).all()
+    prior_ids = {m[0] for m in prior}
+    rec = db.query(Match.user_id).filter(
+        Match.target_user_id == current_user.id,
+        Match.user_id.in_([u.id for u in page]),
+        Match.status.in_(PRIOR_MATCH_STATUSES)
+    ).all()
+    prior_ids |= {m[0] for m in rec}
+
+    return [
+        ProfileDiscoverResponse(profile=UserPublicResponse.model_validate(u), matched_before=(u.id in prior_ids))
+        for u in page
+    ]
 
 
 @router.get("/count", response_model=dict)
@@ -59,10 +78,9 @@ async def get_profile_counts(
     db: Session = Depends(get_db)
 ):
     """Get counts for dashboard summary cards"""
-    # Count profiles available to discover
     interacted_matches = db.query(Match.target_user_id).filter(
         Match.user_id == current_user.id,
-        Match.status.in_(["saved", "dismissed", "viewed"])
+        Match.status.in_(ACTIVE_MATCH_STATUSES)
     ).all()
     interacted_ids = [match[0] for match in interacted_matches]
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -422,3 +422,9 @@ class UserPublicResponse(BaseModel):
         return 0 if v is None else v
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ProfileDiscoverResponse(BaseModel):
+    """Profile in discover/recommendations with optional 'matched before' tag."""
+    profile: UserPublicResponse
+    matched_before: bool = False

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -7,12 +7,12 @@ import Link from "next/link"
 import Image from "next/image"
 import { Sidebar } from "@/components/layout/Sidebar"
 import { api } from "@/lib/api"
-import type { UserPublic } from "@/lib/types"
+import type { ProfileDiscoverItem } from "@/lib/types"
 
 export default function DiscoverPage() {
   const { getToken } = useAuth()
   const router = useRouter()
-  const [profiles, setProfiles] = useState<UserPublic[]>([])
+  const [items, setItems] = useState<ProfileDiscoverItem[]>([])
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState<string | null>(null)
   const [skipping, setSkipping] = useState<string | null>(null)
@@ -33,7 +33,7 @@ export default function DiscoverPage() {
         }
 
         const data = await api.profiles.discover({ limit: 20 }, token)
-        setProfiles(data)
+        setItems(data)
       } catch (error) {
         console.error("Failed to load profiles:", error)
       } finally {
@@ -55,9 +55,8 @@ export default function DiscoverPage() {
       // Mark as saved
       setSavedProfiles((prev) => new Set(prev).add(profileId))
 
-      // Remove from list and move to next
-      setProfiles((prev) => prev.filter((p) => p.id !== profileId))
-      if (currentIndex >= profiles.length - 1) {
+      setItems((prev) => prev.filter((i) => i.profile.id !== profileId))
+      if (currentIndex >= items.length - 1) {
         setCurrentIndex(Math.max(0, currentIndex - 1))
       }
     } catch (error) {
@@ -76,9 +75,8 @@ export default function DiscoverPage() {
       setSkipping(profileId)
       await api.profiles.skip(profileId, token)
 
-      // Remove from list and move to next
-      setProfiles((prev) => prev.filter((p) => p.id !== profileId))
-      if (currentIndex >= profiles.length - 1) {
+      setItems((prev) => prev.filter((i) => i.profile.id !== profileId))
+      if (currentIndex >= items.length - 1) {
         setCurrentIndex(Math.max(0, currentIndex - 1))
       }
     } catch (error) {
@@ -101,15 +99,14 @@ export default function DiscoverPage() {
       if (!token) return
 
       setInviting(currentProfile.id)
-      const result = await api.matches.sendInvite(currentProfile.id, inviteMessage || "Hi! I'd like to connect.", token)
+      const result = await api.matches.sendInvite(currentProfile.id, inviteMessage ?? "Hi! I'd like to connect.", token)
 
       setInvitesRemaining(result.invites_remaining)
       setShowInviteModal(false)
       setInviteMessage("")
 
-      // Remove from list and move to next
-      setProfiles((prev) => prev.filter((p) => p.id !== currentProfile.id))
-      if (currentIndex >= profiles.length - 1) {
+      setItems((prev) => prev.filter((i) => i.profile.id !== currentProfile.id))
+      if (currentIndex >= items.length - 1) {
         setCurrentIndex(Math.max(0, currentIndex - 1))
       }
 
@@ -126,7 +123,8 @@ export default function DiscoverPage() {
     }
   }
 
-  const currentProfile = profiles[currentIndex]
+  const currentItem = items[currentIndex]
+  const currentProfile = currentItem?.profile
 
   if (loading) {
     return (
@@ -142,7 +140,7 @@ export default function DiscoverPage() {
     )
   }
 
-  if (profiles.length === 0) {
+  if (items.length === 0) {
     return (
       <div className="min-h-screen flex">
         <Sidebar />
@@ -172,13 +170,18 @@ export default function DiscoverPage() {
           <div className="mb-6">
             <h1 className="text-3xl font-semibold text-zinc-900 mb-2">Discover Profiles</h1>
             <p className="text-zinc-600">
-              Profile {currentIndex + 1} of {profiles.length}
+              Profile {currentIndex + 1} of {items.length}
               {invitesRemaining !== null && ` • ${invitesRemaining} invites left this week`}
             </p>
           </div>
 
-          {currentProfile && (
+          {currentItem && currentProfile && (
             <div className="bg-white border border-zinc-200 rounded-lg p-8">
+              {currentItem.matched_before && (
+                <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-4">
+                  You matched with this person before
+                </p>
+              )}
               {/* Header with Avatar and Basic Info */}
               <div className="flex items-start gap-6 mb-6">
                 {currentProfile.avatar_url ? (
@@ -343,7 +346,7 @@ export default function DiscoverPage() {
             </div>
           )}
 
-          {profiles.length > 1 && (
+          {items.length > 1 && (
             <div className="mt-6 flex justify-center gap-2">
               <button
                 onClick={() => setCurrentIndex(Math.max(0, currentIndex - 1))}
@@ -353,8 +356,8 @@ export default function DiscoverPage() {
                 Previous
               </button>
               <button
-                onClick={() => setCurrentIndex(Math.min(profiles.length - 1, currentIndex + 1))}
-                disabled={currentIndex === profiles.length - 1}
+                onClick={() => setCurrentIndex(Math.min(items.length - 1, currentIndex + 1))}
+                disabled={currentIndex === items.length - 1}
                 className="px-4 py-2 border border-zinc-300 text-zinc-700 rounded-lg hover:bg-zinc-50 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Next

--- a/frontend/app/inbox/[match_id]/page.tsx
+++ b/frontend/app/inbox/[match_id]/page.tsx
@@ -43,6 +43,7 @@ export default function ConversationPage() {
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
   const [newMessage, setNewMessage] = useState("")
   const [sending, setSending] = useState(false)
+  const [unmatching, setUnmatching] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   const scrollToBottom = () => {
@@ -105,6 +106,23 @@ export default function ConversationPage() {
       alert("Failed to send message. Please try again.")
     } finally {
       setSending(false)
+    }
+  }
+
+  const handleUnmatch = async () => {
+    if (!match || match.status !== "connected") return
+    if (!confirm("Unmatch with this person? They will reappear in your discover feed and can connect again later.")) return
+    try {
+      const token = await getToken()
+      if (!token) return
+      setUnmatching(true)
+      await api.matches.unmatch(matchId, token)
+      router.push("/inbox")
+    } catch (error: any) {
+      console.error("Failed to unmatch:", error)
+      alert(error.message || "Failed to unmatch. Please try again.")
+    } finally {
+      setUnmatching(false)
     }
   }
 
@@ -173,8 +191,18 @@ export default function ConversationPage() {
                 </span>
               </div>
             )}
-            <div>
+            <div className="flex-1 flex items-center justify-between gap-4">
               <h1 className="text-lg font-semibold text-zinc-900">{otherUser.name}</h1>
+              {match.status === "connected" && (
+                <button
+                  type="button"
+                  onClick={handleUnmatch}
+                  disabled={unmatching}
+                  className="text-sm text-zinc-500 hover:text-red-600 transition-colors disabled:opacity-50"
+                >
+                  {unmatching ? "Unmatching..." : "Unmatch"}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import type { User, UserPublic, Organization, Resource, Event } from "./types"
+import type { User, UserPublic, ProfileDiscoverItem, Organization, Resource, Event } from "./types"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
 
@@ -253,7 +253,7 @@ export const api = {
           .filter(([, value]) => value !== undefined)
           .map(([key, value]) => [key, String(value)])
       )
-      return request<UserPublic[]>(`/api/v1/profiles/discover?${queryParams}`, { token })
+      return request<ProfileDiscoverItem[]>(`/api/v1/profiles/discover?${queryParams}`, { token })
     },
 
     getCounts: (token: string) =>
@@ -334,6 +334,12 @@ export const api = {
           token,
         }
       ),
+
+    unmatch: (matchId: string, token: string) =>
+      request<{ message: string; match_id: string }>(`/api/v1/matches/${matchId}/unmatch`, {
+        method: "POST",
+        token,
+      }),
   },
 
   messages: {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -112,6 +112,12 @@ export type UserPublic = {
   portfolio_url?: string
 }
 
+/** Discover/recommendations item: profile plus "matched before" tag when they can reappear after unmatch/dismiss. */
+export type ProfileDiscoverItem = {
+  profile: UserPublic
+  matched_before: boolean
+}
+
 export type Organization = {
   id: string
   name: string


### PR DESCRIPTION
Added 'matched before' tag to profile schema.

Updated discovery logic to hide active matches but allow unmatched profiles to reappear.

Added unmatch functionality to reset discovery status.

Refactored frontend to support new data structures and UI.