### PR TITLE
feat: admin moderation system - report abuse, ban/approve users, moderation dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ coverage.xml
 # Cursor IDE (optional; project state)
 .cursor/
 
+# Linter/formatter caches
+.ruff_cache/
+.mypy_cache/
+
 # Claude-specific files
 docs/CLAUDE.md
 .claude/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,10 @@ CLERK_FRONTEND_API=https://clerk.your-app.lcl.dev
 # Subscribe to event: user.deleted. Then paste the "Signing secret" here.
 # CLERK_WEBHOOK_SECRET=whsec_xxxx
 
+# Admin / Moderation (optional)
+# Comma-separated Clerk user IDs allowed to access /api/v1/admin/* and the Moderation dashboard
+ADMIN_CLERK_IDS=user_39ztDo9pySBTZNjig5OijqOUwJK
+
 # Application Configuration
 ENVIRONMENT=development
 API_V1_PREFIX=/api/v1

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -375,3 +375,24 @@ async def get_clerk_user_info_from_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials"
         )
+
+
+def get_admin_clerk_ids() -> set[str]:
+    """Parse ADMIN_CLERK_IDS from settings into a set of clerk IDs."""
+    raw = (settings.ADMIN_CLERK_IDS or "").strip()
+    if not raw:
+        return set()
+    return {x.strip() for x in raw.split(",") if x.strip()}
+
+
+async def get_current_admin_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Require current user to be an admin (clerk_id in ADMIN_CLERK_IDS)."""
+    admin_ids = get_admin_clerk_ids()
+    if not admin_ids or current_user.clerk_id not in admin_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1 import users, organizations, resources, events, profiles, matches, messages
+from app.api.v1 import users, organizations, resources, events, profiles, matches, messages, reports, admin
 
 api_router = APIRouter()
 
@@ -10,3 +10,5 @@ api_router.include_router(events.router, prefix="/events", tags=["events"])
 api_router.include_router(profiles.router, prefix="/profiles", tags=["profiles"])
 api_router.include_router(matches.router, prefix="/matches", tags=["matches"])
 api_router.include_router(messages.router, prefix="/messages", tags=["messages"])
+api_router.include_router(reports.router, prefix="/reports", tags=["reports"])
+api_router.include_router(admin.router, prefix="/admin", tags=["admin"])

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -1,0 +1,243 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from uuid import UUID
+from datetime import datetime, timezone
+
+from app.database import get_db
+from app.models.report import Report
+from app.models.user import User
+from app.models.organization import Organization
+from app.schemas.report import ReportReview, ReportListItem
+from app.schemas.user import UserResponse
+from app.schemas.organization import OrganizationResponse
+from app.api.deps import get_current_user, get_current_admin_user, get_admin_clerk_ids
+from app.config import settings
+
+router = APIRouter()
+
+
+@router.get("/check")
+def admin_check(current_user: User = Depends(get_current_user)):
+    """Return whether the current user is an admin (for UI to show/hide admin link)."""
+    admin_ids = get_admin_clerk_ids()
+    is_admin = current_user.clerk_id in admin_ids
+    out: dict = {"is_admin": is_admin}
+    if not is_admin and settings.ENVIRONMENT != "production":
+        if not admin_ids:
+            out["hint"] = "ADMIN_CLERK_IDS is not set. Add it to backend/.env (see backend/.env.example)."
+        else:
+            out["hint"] = "Your Clerk user ID is not in ADMIN_CLERK_IDS. Check backend/.env."
+    return out
+
+
+@router.get("/stats")
+def admin_stats(
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Return counts for admin overview (users, reports, organizations)."""
+    users_total = db.query(func.count(User.id)).scalar() or 0
+    users_banned = db.query(func.count(User.id)).filter(User.is_banned.is_(True)).scalar() or 0
+    users_pending_review = (
+        db.query(func.count(User.id)).filter(User.profile_status == "pending_review").scalar() or 0
+    )
+    reports_pending = db.query(func.count(Report.id)).filter(Report.status == "pending").scalar() or 0
+    reports_total = db.query(func.count(Report.id)).scalar() or 0
+    organizations_total = db.query(func.count(Organization.id)).scalar() or 0
+    return {
+        "users_total": users_total,
+        "users_banned": users_banned,
+        "users_pending_review": users_pending_review,
+        "reports_pending": reports_pending,
+        "reports_total": reports_total,
+        "organizations_total": organizations_total,
+    }
+
+
+@router.get("/reports", response_model=list[ReportListItem])
+def list_reports(
+    status_filter: str | None = Query(None, description="Filter by status: pending, reviewed, resolved, dismissed"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List reports with optional status filter. Paginated."""
+    q = db.query(Report).order_by(Report.created_at.desc())
+    if status_filter and status_filter in ("pending", "reviewed", "resolved", "dismissed"):
+        q = q.filter(Report.status == status_filter)
+    reports = q.offset(skip).limit(limit).all()
+    return [
+        ReportListItem(
+            id=r.id,
+            reporter_id=r.reporter_id,
+            reported_user_id=r.reported_user_id,
+            report_type=r.report_type,
+            description=r.description,
+            status=r.status,
+            reviewed_by=r.reviewed_by,
+            reviewed_at=r.reviewed_at,
+            resolution_notes=r.resolution_notes,
+            created_at=r.created_at,
+            reporter_name=r.reporter.name if r.reporter else None,
+            reporter_email=r.reporter.email if r.reporter else None,
+            reported_user_name=r.reported_user.name if r.reported_user else None,
+            reported_user_email=r.reported_user.email if r.reported_user else None,
+        )
+        for r in reports
+    ]
+
+
+@router.put("/reports/{report_id}", response_model=ReportListItem)
+def review_report(
+    report_id: UUID,
+    body: ReportReview,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Update report status and resolution notes."""
+    r = db.query(Report).filter(Report.id == report_id).first()
+    if not r:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+    r.status = body.status
+    r.resolution_notes = body.resolution_notes
+    r.reviewed_by = admin.id
+    r.reviewed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(r)
+    return ReportListItem(
+        id=r.id,
+        reporter_id=r.reporter_id,
+        reported_user_id=r.reported_user_id,
+        report_type=r.report_type,
+        description=r.description,
+        status=r.status,
+        reviewed_by=r.reviewed_by,
+        reviewed_at=r.reviewed_at,
+        resolution_notes=r.resolution_notes,
+        created_at=r.created_at,
+        reporter_name=r.reporter.name if r.reporter else None,
+        reporter_email=r.reporter.email if r.reporter else None,
+        reported_user_name=r.reported_user.name if r.reported_user else None,
+        reported_user_email=r.reported_user.email if r.reported_user else None,
+    )
+
+
+@router.get("/users", response_model=list[UserResponse])
+def list_users(
+    profile_status: str | None = Query(None, description="Filter by profile_status"),
+    is_banned: bool | None = Query(None, description="Filter by is_banned"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List users for moderation. Paginated."""
+    q = db.query(User).order_by(User.created_at.desc())
+    if profile_status:
+        q = q.filter(User.profile_status == profile_status)
+    if is_banned is not None:
+        q = q.filter(User.is_banned == is_banned)
+    users = q.offset(skip).limit(limit).all()
+    return users
+
+
+@router.put("/users/{user_id}/ban")
+def ban_user(
+    user_id: UUID,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Ban a user. They will receive 403 on authenticated requests."""
+    if user_id == admin.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot ban yourself")
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.is_banned = True
+    db.commit()
+    db.refresh(user)
+    return {"message": "User banned", "user_id": str(user_id)}
+
+
+@router.put("/users/{user_id}/unban")
+def unban_user(
+    user_id: UUID,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Remove ban from a user."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.is_banned = False
+    db.commit()
+    db.refresh(user)
+    return {"message": "User unbanned", "user_id": str(user_id)}
+
+
+@router.put("/users/{user_id}/approve")
+def approve_user(
+    user_id: UUID,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Set user profile_status to approved (e.g. after review)."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.profile_status = "approved"
+    db.commit()
+    db.refresh(user)
+    return {"message": "User approved", "user_id": str(user_id)}
+
+
+@router.put("/users/{user_id}/reject")
+def reject_user(
+    user_id: UUID,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Set user profile_status to rejected."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user.profile_status = "rejected"
+    db.commit()
+    db.refresh(user)
+    return {"message": "User rejected", "user_id": str(user_id)}
+
+
+@router.get("/organizations", response_model=list[OrganizationResponse])
+def list_organizations_admin(
+    verified: bool | None = Query(None, description="Filter by is_verified"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List all organizations for admin. Paginated."""
+    q = db.query(Organization).order_by(Organization.name)
+    if verified is not None:
+        q = q.filter(Organization.is_verified == verified)
+    orgs = q.offset(skip).limit(limit).all()
+    return orgs
+
+
+@router.put("/organizations/{org_id}/verify")
+def verify_organization(
+    org_id: UUID,
+    admin: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Mark organization as verified."""
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    org.is_verified = True
+    org.verification_method = "manual"
+    org.verified_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(org)
+    return {"message": "Organization verified", "org_id": str(org_id)}

--- a/backend/app/api/v1/reports.py
+++ b/backend/app/api/v1/reports.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.report import Report
+from app.models.user import User
+from app.schemas.report import ReportCreate, ReportResponse
+from app.api.deps import get_current_user
+
+router = APIRouter()
+
+
+@router.post("", response_model=ReportResponse, status_code=status.HTTP_201_CREATED)
+def create_report(
+    body: ReportCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Submit a report against a user (e.g. abuse, spam)."""
+    if body.reported_user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot report yourself",
+        )
+    reported = db.query(User).filter(User.id == body.reported_user_id).first()
+    if not reported:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    if reported.is_banned:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User is already banned",
+        )
+    report = Report(
+        reporter_id=current_user.id,
+        reported_user_id=body.reported_user_id,
+        report_type=body.report_type,
+        description=body.description,
+        status="pending",
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     CORS_ORIGINS: str = "http://localhost:3000,http://localhost:3001"  # Comma-separated list of allowed origins
     CLERK_FRONTEND_API: str = ""  # Optional: Clerk instance URL (e.g., https://your-instance.clerk.accounts.dev)
     CLERK_WEBHOOK_SECRET: str = ""  # Optional: Clerk webhook signing secret (from Dashboard → Webhooks → endpoint)
+    ADMIN_CLERK_IDS: str = ""  # Comma-separated Clerk user IDs allowed to access admin/moderation endpoints
 
     class Config:
         env_file = ".env"

--- a/backend/app/constants/enums.py
+++ b/backend/app/constants/enums.py
@@ -12,6 +12,8 @@ STARTUP_FUNDING = ["bootstrapped", "pre_seed", "seed", "none"]
 PREF_IDEA_STATUSES = ["not_set_on_idea", "has_their_own_ideas", "no_preference"]
 PREF_LOCATION_TYPES = ["within_distance", "same_country", "same_region", "no_preference"]
 PROFILE_STATUSES = ["incomplete", "pending_review", "approved", "rejected"]
+REPORT_TYPES = ["spam", "abuse", "inappropriate", "fake", "other"]
+REPORT_STATUSES = ["pending", "reviewed", "resolved", "dismissed"]
 
 TOPICS_OF_INTEREST = [
     "Artificial Intelligence",

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, String, Text, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, TIMESTAMP
+from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import uuid
 
@@ -28,6 +29,9 @@ class Report(Base):
 
     # Metadata
     created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+    reporter = relationship("User", foreign_keys=[reporter_id])
+    reported_user = relationship("User", foreign_keys=[reported_user_id])
 
     def __repr__(self) -> str:
         return f"<Report type={self.report_type} status={self.status}>"

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel, Field, field_validator
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+
+from app.constants.enums import REPORT_TYPES
+
+
+class ReportCreate(BaseModel):
+    reported_user_id: UUID
+    report_type: str = Field(..., description="One of: spam, abuse, inappropriate, fake, other")
+    description: str = Field(..., min_length=10, max_length=2000)
+
+    @field_validator("report_type")
+    @classmethod
+    def report_type_one_of(cls, v: str) -> str:
+        if v not in REPORT_TYPES:
+            raise ValueError(f"report_type must be one of {REPORT_TYPES}")
+        return v
+
+
+class ReportReview(BaseModel):
+    status: str = Field(..., description="One of: reviewed, resolved, dismissed")
+    resolution_notes: Optional[str] = Field(None, max_length=2000)
+
+    @field_validator("status")
+    @classmethod
+    def status_one_of(cls, v: str) -> str:
+        if v not in ("reviewed", "resolved", "dismissed"):
+            raise ValueError("status must be one of: reviewed, resolved, dismissed")
+        return v
+
+
+class ReportResponse(BaseModel):
+    id: UUID
+    reporter_id: Optional[UUID]
+    reported_user_id: Optional[UUID]
+    report_type: str
+    description: str
+    status: str
+    reviewed_by: Optional[UUID]
+    reviewed_at: Optional[datetime]
+    resolution_notes: Optional[str]
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ReportListItem(ReportResponse):
+    reporter_name: Optional[str] = None
+    reporter_email: Optional[str] = None
+    reported_user_name: Optional[str] = None
+    reported_user_email: Optional[str] = None

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,534 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAuth } from "@clerk/nextjs"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { Sidebar } from "@/components/layout/Sidebar"
+import { api } from "@/lib/api"
+import type { ReportListItem, User } from "@/lib/types"
+import type { Organization } from "@/lib/types"
+
+type AdminTab = "overview" | "reports" | "users" | "organizations"
+
+type Stats = {
+  users_total: number
+  users_banned: number
+  users_pending_review: number
+  reports_pending: number
+  reports_total: number
+  organizations_total: number
+}
+
+export default function AdminPage() {
+  const { getToken } = useAuth()
+  const router = useRouter()
+  const [tab, setTab] = useState<AdminTab>("overview")
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null)
+  const [accessDeniedHint, setAccessDeniedHint] = useState<string | null>(null)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [reports, setReports] = useState<ReportListItem[]>([])
+  const [users, setUsers] = useState<User[]>([])
+  const [organizations, setOrganizations] = useState<Organization[]>([])
+  const [reportStatusFilter, setReportStatusFilter] = useState("pending")
+  const [userFilter, setUserFilter] = useState<"all" | "banned" | "pending_review">("all")
+  const [loading, setLoading] = useState(true)
+  const [actioning, setActioning] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function check() {
+      try {
+        const token = await getToken()
+        if (!token) {
+          router.push("/")
+          return
+        }
+        const res = await api.admin.check(token)
+        if (!cancelled) {
+          setIsAdmin(res.is_admin)
+          if (!res.is_admin && res.hint) setAccessDeniedHint(res.hint)
+        }
+      } catch {
+        if (!cancelled) setIsAdmin(false)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    check()
+    return () => {
+      cancelled = true
+    }
+  }, [getToken, router])
+
+  useEffect(() => {
+    if (!isAdmin) return
+    getToken().then((token) => {
+      if (!token) return
+      api.admin.getStats(token).then(setStats).catch(() => {})
+    })
+  }, [isAdmin, getToken])
+
+  useEffect(() => {
+    if (!isAdmin || tab !== "reports") return
+    getToken().then((token) => {
+      if (!token) return
+      api.admin.getReports(token, { status_filter: reportStatusFilter, limit: 100 }).then(setReports).catch(() => {})
+    })
+  }, [isAdmin, tab, reportStatusFilter, getToken])
+
+  useEffect(() => {
+    if (!isAdmin || tab !== "users") return
+    getToken().then((token) => {
+      if (!token) return
+      const params: { limit: number; is_banned?: boolean; profile_status?: string } = { limit: 100 }
+      if (userFilter === "banned") params.is_banned = true
+      if (userFilter === "pending_review") params.profile_status = "pending_review"
+      api.admin.getUsers(token, params).then(setUsers).catch(() => {})
+    })
+  }, [isAdmin, tab, userFilter, getToken])
+
+  useEffect(() => {
+    if (!isAdmin || tab !== "organizations") return
+    getToken().then((token) => {
+      if (!token) return
+      api.admin.getOrganizations(token, { limit: 100 }).then(setOrganizations).catch(() => {})
+    })
+  }, [isAdmin, tab, getToken])
+
+  const handleReviewReport = async (reportId: string, status: string) => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(reportId)
+      await api.admin.reviewReport(reportId, status, null, token)
+      setReports((prev) => prev.filter((r) => r.id !== reportId))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to update report")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const handleBan = async (userId: string) => {
+    if (!confirm("Ban this user? They will not be able to sign in.")) return
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(userId)
+      await api.admin.banUser(userId, token)
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, is_banned: true } : u)))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to ban user")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const handleUnban = async (userId: string) => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(userId)
+      await api.admin.unbanUser(userId, token)
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, is_banned: false } : u)))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to unban user")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const handleApprove = async (userId: string) => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(userId)
+      await api.admin.approveUser(userId, token)
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, profile_status: "approved" } : u)))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to approve user")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const handleReject = async (userId: string) => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(userId)
+      await api.admin.rejectUser(userId, token)
+      setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, profile_status: "rejected" } : u)))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to reject user")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const handleVerifyOrg = async (orgId: string) => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setActioning(orgId)
+      await api.admin.verifyOrganization(orgId, token)
+      setOrganizations((prev) => prev.map((o) => (o.id === orgId ? { ...o, is_verified: true } : o)))
+    } catch (e) {
+      console.error(e)
+      alert("Failed to verify organization")
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const formatDate = (s: string | null) => (s ? new Date(s).toLocaleString() : "-")
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900" />
+      </div>
+    )
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen flex">
+        <Sidebar />
+        <main className="flex-1 p-8 flex items-center justify-center">
+          <div className="text-center max-w-md">
+            <h1 className="text-2xl font-semibold text-zinc-900 mb-2">Access denied</h1>
+            <p className="text-zinc-600 mb-6">
+              You do not have permission to view the admin area. If you believe this is an error, contact your
+              administrator.
+            </p>
+            {accessDeniedHint && (
+              <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mb-6 text-left">
+                {accessDeniedHint}
+              </p>
+            )}
+            <Link
+              href="/dashboard"
+              className="inline-block px-6 py-2 bg-zinc-900 text-white font-medium rounded-lg hover:bg-zinc-800"
+            >
+              Back to Dashboard
+            </Link>
+          </div>
+        </main>
+      </div>
+    )
+  }
+
+  const tabs: { id: AdminTab; label: string }[] = [
+    { id: "overview", label: "Overview" },
+    { id: "reports", label: "Reports" },
+    { id: "users", label: "Users" },
+    { id: "organizations", label: "Organizations" },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-8 overflow-auto">
+        <div className="max-w-6xl mx-auto">
+          <h1 className="text-3xl font-semibold text-zinc-900 mb-2">Admin</h1>
+          <p className="text-zinc-600 mb-6">Manage users, reports, and organizations.</p>
+
+          <nav className="flex gap-1 border-b border-zinc-200 mb-8">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                className={`px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors ${
+                  tab === t.id
+                    ? "bg-white border border-zinc-200 border-b-0 text-zinc-900 -mb-px"
+                    : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100"
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          {tab === "overview" && stats && (
+            <div className="space-y-6">
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Total users</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.users_total}</p>
+                </div>
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Pending review</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.users_pending_review}</p>
+                  <button
+                    type="button"
+                    onClick={() => setTab("users")}
+                    className="text-xs text-zinc-600 hover:underline mt-1"
+                  >
+                    View
+                  </button>
+                </div>
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Banned</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.users_banned}</p>
+                </div>
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Pending reports</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.reports_pending}</p>
+                  <button
+                    type="button"
+                    onClick={() => setTab("reports")}
+                    className="text-xs text-zinc-600 hover:underline mt-1"
+                  >
+                    Review
+                  </button>
+                </div>
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Total reports</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.reports_total}</p>
+                </div>
+                <div className="bg-white border border-zinc-200 rounded-lg p-4">
+                  <p className="text-sm text-zinc-500">Organizations</p>
+                  <p className="text-2xl font-semibold text-zinc-900">{stats.organizations_total}</p>
+                  <button
+                    type="button"
+                    onClick={() => setTab("organizations")}
+                    className="text-xs text-zinc-600 hover:underline mt-1"
+                  >
+                    Manage
+                  </button>
+                </div>
+              </div>
+              <div className="bg-white border border-zinc-200 rounded-lg p-6">
+                <h2 className="text-lg font-medium text-zinc-900 mb-4">Quick actions</h2>
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setTab("reports")}
+                    className="px-4 py-2 bg-zinc-900 text-white text-sm font-medium rounded-lg hover:bg-zinc-800"
+                  >
+                    Review reports
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setTab("users"); setUserFilter("pending_review") }}
+                    className="px-4 py-2 border border-zinc-300 text-zinc-700 text-sm font-medium rounded-lg hover:bg-zinc-50"
+                  >
+                    Approve profiles
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTab("users")}
+                    className="px-4 py-2 border border-zinc-300 text-zinc-700 text-sm font-medium rounded-lg hover:bg-zinc-50"
+                  >
+                    Manage users
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTab("organizations")}
+                    className="px-4 py-2 border border-zinc-300 text-zinc-700 text-sm font-medium rounded-lg hover:bg-zinc-50"
+                  >
+                    Verify organizations
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {tab === "reports" && (
+            <>
+              <div className="mb-4 flex gap-2 items-center">
+                <label className="text-sm font-medium text-zinc-700">Status</label>
+                <select
+                  value={reportStatusFilter}
+                  onChange={(e) => setReportStatusFilter(e.target.value)}
+                  className="border border-zinc-300 rounded px-3 py-1.5 text-zinc-900"
+                >
+                  <option value="pending">Pending</option>
+                  <option value="reviewed">Reviewed</option>
+                  <option value="resolved">Resolved</option>
+                  <option value="dismissed">Dismissed</option>
+                </select>
+              </div>
+              <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+                {reports.length === 0 ? (
+                  <p className="p-6 text-zinc-600">No reports in this status.</p>
+                ) : (
+                  <div className="divide-y divide-zinc-200">
+                    {reports.map((r) => (
+                      <div key={r.id} className="p-4 flex justify-between items-start gap-4">
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm text-zinc-500">
+                            Reported: {r.reported_user_name ?? "Unknown"} ({r.reported_user_email ?? "-"})
+                          </p>
+                          <p className="text-sm text-zinc-500">
+                            Reporter: {r.reporter_name ?? "Anonymous"} ({r.reporter_email ?? "-"})
+                          </p>
+                          <p className="mt-1 font-medium text-zinc-900">{r.report_type}</p>
+                          <p className="text-zinc-700 mt-1">{r.description}</p>
+                          <p className="text-xs text-zinc-400 mt-2">{formatDate(r.created_at)}</p>
+                        </div>
+                        {r.status === "pending" && (
+                          <div className="flex gap-2 flex-shrink-0">
+                            <button
+                              type="button"
+                              onClick={() => handleReviewReport(r.id, "resolved")}
+                              disabled={actioning === r.id}
+                              className="px-3 py-1.5 text-sm bg-zinc-900 text-white rounded hover:bg-zinc-800 disabled:opacity-50"
+                            >
+                              Resolve
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleReviewReport(r.id, "dismissed")}
+                              disabled={actioning === r.id}
+                              className="px-3 py-1.5 text-sm border border-zinc-300 text-zinc-700 rounded hover:bg-zinc-50 disabled:opacity-50"
+                            >
+                              Dismiss
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {tab === "users" && (
+            <>
+              <div className="mb-4 flex gap-2 items-center">
+                <label className="text-sm font-medium text-zinc-700">Filter</label>
+                <select
+                  value={userFilter}
+                  onChange={(e) => setUserFilter(e.target.value as "all" | "banned" | "pending_review")}
+                  className="border border-zinc-300 rounded px-3 py-1.5 text-zinc-900"
+                >
+                  <option value="all">All users</option>
+                  <option value="pending_review">Pending review</option>
+                  <option value="banned">Banned</option>
+                </select>
+              </div>
+              <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+                {users.length === 0 ? (
+                  <p className="p-6 text-zinc-600">No users match the filter.</p>
+                ) : (
+                  <table className="w-full text-left">
+                    <thead className="bg-zinc-50 border-b border-zinc-200">
+                      <tr>
+                        <th className="px-4 py-3 text-sm font-medium text-zinc-900">Name</th>
+                        <th className="px-4 py-3 text-sm font-medium text-zinc-900">Email</th>
+                        <th className="px-4 py-3 text-sm font-medium text-zinc-900">Profile status</th>
+                        <th className="px-4 py-3 text-sm font-medium text-zinc-900">Banned</th>
+                        <th className="px-4 py-3 text-sm font-medium text-zinc-900">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-zinc-200">
+                      {users.map((u) => (
+                        <tr key={u.id}>
+                          <td className="px-4 py-3 text-zinc-900">{u.name}</td>
+                          <td className="px-4 py-3 text-zinc-600">{u.email}</td>
+                          <td className="px-4 py-3 text-zinc-700">{u.profile_status ?? "incomplete"}</td>
+                          <td className="px-4 py-3">{u.is_banned ? "Yes" : "No"}</td>
+                          <td className="px-4 py-3 flex gap-2 flex-wrap">
+                            {u.is_banned ? (
+                              <button
+                                type="button"
+                                onClick={() => handleUnban(u.id)}
+                                disabled={actioning === u.id}
+                                className="text-sm text-zinc-600 hover:underline disabled:opacity-50"
+                              >
+                                Unban
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => handleBan(u.id)}
+                                disabled={actioning === u.id}
+                                className="text-sm text-red-600 hover:underline disabled:opacity-50"
+                              >
+                                Ban
+                              </button>
+                            )}
+                            {u.profile_status === "pending_review" && (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => handleApprove(u.id)}
+                                  disabled={actioning === u.id}
+                                  className="text-sm text-green-600 hover:underline disabled:opacity-50"
+                                >
+                                  Approve
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => handleReject(u.id)}
+                                  disabled={actioning === u.id}
+                                  className="text-sm text-zinc-600 hover:underline disabled:opacity-50"
+                                >
+                                  Reject
+                                </button>
+                              </>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            </>
+          )}
+
+          {tab === "organizations" && (
+            <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+              {organizations.length === 0 ? (
+                <p className="p-6 text-zinc-600">No organizations.</p>
+              ) : (
+                <table className="w-full text-left">
+                  <thead className="bg-zinc-50 border-b border-zinc-200">
+                    <tr>
+                      <th className="px-4 py-3 text-sm font-medium text-zinc-900">Name</th>
+                      <th className="px-4 py-3 text-sm font-medium text-zinc-900">Slug</th>
+                      <th className="px-4 py-3 text-sm font-medium text-zinc-900">Verified</th>
+                      <th className="px-4 py-3 text-sm font-medium text-zinc-900">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-200">
+                    {organizations.map((o) => (
+                      <tr key={o.id}>
+                        <td className="px-4 py-3 text-zinc-900">{o.name}</td>
+                        <td className="px-4 py-3 text-zinc-600">{o.slug}</td>
+                        <td className="px-4 py-3">{o.is_verified ? "Yes" : "No"}</td>
+                        <td className="px-4 py-3">
+                          {!o.is_verified && (
+                            <button
+                              type="button"
+                              onClick={() => handleVerifyOrg(o.id)}
+                              disabled={actioning === o.id}
+                              className="text-sm text-green-600 hover:underline disabled:opacity-50"
+                            >
+                              Verify
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/app/profile/[id]/page.tsx
+++ b/frontend/app/profile/[id]/page.tsx
@@ -9,6 +9,14 @@ import { Sidebar } from "@/components/layout/Sidebar"
 import { api } from "@/lib/api"
 import type { UserPublic } from "@/lib/types"
 
+const REPORT_TYPES = [
+  { value: "spam", label: "Spam" },
+  { value: "abuse", label: "Abuse or harassment" },
+  { value: "inappropriate", label: "Inappropriate content" },
+  { value: "fake", label: "Fake or misleading profile" },
+  { value: "other", label: "Other" },
+] as const
+
 export default function ProfileDetailPage() {
   const { getToken } = useAuth()
   const router = useRouter()
@@ -19,6 +27,11 @@ export default function ProfileDetailPage() {
   const [saving, setSaving] = useState(false)
   const [skipping, setSkipping] = useState(false)
   const [isSaved, setIsSaved] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
+  const [reportType, setReportType] = useState("abuse")
+  const [reportDesc, setReportDesc] = useState("")
+  const [reportSubmitting, setReportSubmitting] = useState(false)
+  const [reportDone, setReportDone] = useState(false)
 
   useEffect(() => {
     async function loadProfile() {
@@ -73,6 +86,27 @@ export default function ProfileDetailPage() {
       console.error("Failed to skip profile:", error)
     } finally {
       setSkipping(false)
+    }
+  }
+
+  const handleReportSubmit = async () => {
+    if (!profile || reportDesc.trim().length < 10) return
+    try {
+      const token = await getToken()
+      if (!token) return
+      setReportSubmitting(true)
+      await api.reports.create(profile.id, reportType, reportDesc.trim(), token)
+      setReportDone(true)
+      setTimeout(() => {
+        setReportOpen(false)
+        setReportDone(false)
+        setReportDesc("")
+      }, 1500)
+    } catch (error) {
+      console.error("Report failed:", error)
+      alert(error instanceof Error ? error.message : "Failed to submit report.")
+    } finally {
+      setReportSubmitting(false)
     }
   }
 
@@ -232,6 +266,63 @@ export default function ProfileDetailPage() {
                 {saving ? "Saving..." : isSaved ? "Saved" : "Save for Later"}
               </button>
             </div>
+            <div className="pt-4 text-center">
+              <button
+                type="button"
+                onClick={() => setReportOpen(true)}
+                className="text-sm text-zinc-500 hover:text-zinc-700 underline"
+              >
+                Report this profile
+              </button>
+            </div>
+            {reportOpen && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+                <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+                  <h3 className="text-lg font-semibold text-zinc-900 mb-4">Report profile</h3>
+                  {reportDone ? (
+                    <p className="text-zinc-700">Thank you. Your report has been submitted and will be reviewed.</p>
+                  ) : (
+                    <>
+                      <label className="block text-sm font-medium text-zinc-700 mb-2">Reason</label>
+                      <select
+                        value={reportType}
+                        onChange={(e) => setReportType(e.target.value)}
+                        className="w-full border border-zinc-300 rounded-lg px-3 py-2 text-zinc-900 mb-4"
+                      >
+                        {REPORT_TYPES.map((t) => (
+                          <option key={t.value} value={t.value}>{t.label}</option>
+                        ))}
+                      </select>
+                      <label className="block text-sm font-medium text-zinc-700 mb-2">Details (min 10 characters)</label>
+                      <textarea
+                        value={reportDesc}
+                        onChange={(e) => setReportDesc(e.target.value)}
+                        placeholder="Describe what happened..."
+                        rows={4}
+                        className="w-full border border-zinc-300 rounded-lg px-3 py-2 text-zinc-900 placeholder-zinc-400 mb-4"
+                      />
+                      <div className="flex gap-3 justify-end">
+                        <button
+                          type="button"
+                          onClick={() => { setReportOpen(false); setReportDesc("") }}
+                          className="px-4 py-2 text-zinc-700 hover:bg-zinc-100 rounded-lg"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleReportSubmit}
+                          disabled={reportSubmitting || reportDesc.trim().length < 10}
+                          className="px-4 py-2 bg-zinc-900 text-white rounded-lg hover:bg-zinc-800 disabled:opacity-50"
+                        >
+                          {reportSubmitting ? "Submitting..." : "Submit report"}
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,15 +1,18 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { UserButton } from "@clerk/nextjs"
+import { UserButton, useAuth } from "@clerk/nextjs"
 import { clsx } from "clsx"
+import { api } from "@/lib/api"
 
 type NavItem = {
   label: string
   href: string
   icon: React.ReactNode
   hasSubmenu?: boolean
+  adminOnly?: boolean
 }
 
 const navItems: NavItem[] = [
@@ -60,10 +63,40 @@ const navItems: NavItem[] = [
     ),
     hasSubmenu: true,
   },
+  {
+    label: "Admin",
+    href: "/admin",
+    adminOnly: true,
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+  },
 ]
 
 export function Sidebar() {
   const pathname = usePathname()
+  const { getToken } = useAuth()
+  const [isAdmin, setIsAdmin] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getToken()
+      .then((token) => {
+        if (!token || cancelled) return
+        return api.admin.check(token)
+      })
+      .then((res) => {
+        if (!cancelled && res?.is_admin) setIsAdmin(true)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [getToken])
+
+  const items = navItems.filter((item) => !item.adminOnly || isAdmin)
 
   return (
     <div className="w-64 bg-white border-r border-zinc-200 min-h-screen flex flex-col">
@@ -72,8 +105,11 @@ export function Sidebar() {
       </div>
 
       <nav className="flex-1 p-4 space-y-1">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href || (item.href !== "/dashboard" && pathname?.startsWith(item.href))
+        {items.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== "/dashboard" && item.href !== "/admin" && pathname?.startsWith(item.href)) ||
+            (item.href === "/admin" && pathname?.startsWith("/admin"))
           
           return (
             <Link

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import type { User, UserPublic, ProfileDiscoverItem, Organization, Resource, Event } from "./types"
+import type { User, UserPublic, ProfileDiscoverItem, Organization, Resource, Event, ReportListItem } from "./types"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
 
@@ -370,6 +370,94 @@ export const api = {
 
     markRead: (messageId: string, token: string) =>
       request<any>(`/api/v1/messages/${messageId}/read`, {
+        method: "PUT",
+        token,
+      }),
+  },
+
+  reports: {
+    create: (reportedUserId: string, reportType: string, description: string, token: string) =>
+      request<ReportListItem>("/api/v1/reports", {
+        method: "POST",
+        body: JSON.stringify({ reported_user_id: reportedUserId, report_type: reportType, description }),
+        token,
+      }),
+  },
+
+  admin: {
+    check: (token: string) =>
+      request<{ is_admin: boolean; hint?: string }>("/api/v1/admin/check", { token }),
+
+    getStats: (token: string) =>
+      request<{
+        users_total: number
+        users_banned: number
+        users_pending_review: number
+        reports_pending: number
+        reports_total: number
+        organizations_total: number
+      }>("/api/v1/admin/stats", { token }),
+
+    getReports: (token: string, params?: { status_filter?: string; skip?: number; limit?: number }) => {
+      const queryParams = new URLSearchParams(
+        Object.entries(params || {})
+          .filter(([, value]) => value !== undefined)
+          .map(([key, value]) => [key, String(value)])
+      )
+      return request<ReportListItem[]>(`/api/v1/admin/reports?${queryParams}`, { token })
+    },
+
+    reviewReport: (reportId: string, status: string, resolutionNotes: string | null, token: string) =>
+      request<ReportListItem>(`/api/v1/admin/reports/${reportId}`, {
+        method: "PUT",
+        body: JSON.stringify({ status, resolution_notes: resolutionNotes }),
+        token,
+      }),
+
+    getUsers: (token: string, params?: { profile_status?: string; is_banned?: boolean; skip?: number; limit?: number }) => {
+      const queryParams = new URLSearchParams(
+        Object.entries(params || {})
+          .filter(([, value]) => value !== undefined)
+          .map(([key, value]) => [key, String(value)])
+      )
+      return request<User[]>(`/api/v1/admin/users?${queryParams}`, { token })
+    },
+
+    banUser: (userId: string, token: string) =>
+      request<{ message: string; user_id: string }>(`/api/v1/admin/users/${userId}/ban`, {
+        method: "PUT",
+        token,
+      }),
+
+    unbanUser: (userId: string, token: string) =>
+      request<{ message: string; user_id: string }>(`/api/v1/admin/users/${userId}/unban`, {
+        method: "PUT",
+        token,
+      }),
+
+    approveUser: (userId: string, token: string) =>
+      request<{ message: string; user_id: string }>(`/api/v1/admin/users/${userId}/approve`, {
+        method: "PUT",
+        token,
+      }),
+
+    rejectUser: (userId: string, token: string) =>
+      request<{ message: string; user_id: string }>(`/api/v1/admin/users/${userId}/reject`, {
+        method: "PUT",
+        token,
+      }),
+
+    getOrganizations: (token: string, params?: { verified?: boolean; skip?: number; limit?: number }) => {
+      const queryParams = new URLSearchParams(
+        Object.entries(params || {})
+          .filter(([, value]) => value !== undefined)
+          .map(([key, value]) => [key, String(value)])
+      )
+      return request<Organization[]>(`/api/v1/admin/organizations?${queryParams}`, { token })
+    },
+
+    verifyOrganization: (orgId: string, token: string) =>
+      request<{ message: string; org_id: string }>(`/api/v1/admin/organizations/${orgId}/verify`, {
         method: "PUT",
         token,
       }),

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -12,6 +12,8 @@ export type ReadyToStart = "now" | "1_month" | "3_months" | "6_months" | "explor
 export type ImportanceLevel = "required" | "preferred" | "not_important"
 export type ProfileStatus = "incomplete" | "pending_review" | "approved" | "rejected"
 export type WorkLocationPreference = "remote" | "in_person" | "hybrid"
+export type ReportType = "spam" | "abuse" | "inappropriate" | "fake" | "other"
+export type ReportStatus = "pending" | "reviewed" | "resolved" | "dismissed"
 
 export type SkillItem = {
   name: string
@@ -183,4 +185,21 @@ export type Event = {
   is_active: boolean
   created_at: string
   updated_at: string
+}
+
+export type ReportListItem = {
+  id: string
+  reporter_id: string | null
+  reported_user_id: string | null
+  report_type: ReportType
+  description: string
+  status: ReportStatus
+  reviewed_by: string | null
+  reviewed_at: string | null
+  resolution_notes: string | null
+  created_at: string
+  reporter_name: string | null
+  reporter_email: string | null
+  reported_user_name: string | null
+  reported_user_email: string | null
 }


### PR DESCRIPTION
- Backend: ADMIN_CLERK_IDS config, get_current_admin_user dependency
- POST /api/v1/reports for users to report abuse (reported_user_id, type, description)
- Admin: GET /check (is_admin), GET /stats, GET/PUT reports, GET users, ban/unban/approve/reject
- Admin: GET organizations, PUT organization verify
- Frontend: report modal on profile page, Admin link in sidebar (visible only to admins)
- Admin dashboard: Overview (stats + quick actions), Reports, Users (filters), Organizations (verify)
- Access denied view with dev hint when ADMIN_CLERK_IDS missing or user not listed