### PR TITLE
comprehensive security hardening (closes #25)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
           pip install ruff
           ruff check . --output-format=github
 
+      - name: Run Bandit SAST
+        working-directory: ./backend
+        run: |
+          pip install bandit
+          bandit -r app/ -ll -x app/tests/
+
       - name: Run tests with pytest
         working-directory: ./backend
         env:
@@ -165,3 +171,27 @@ jobs:
         if: always() && steps.check-sarif.outputs.exists == 'true'
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Set up Python for pip-audit
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run pip-audit (Python dependency scan)
+        working-directory: ./backend
+        run: |
+          pip install pip-audit
+          pip-audit -r requirements.txt
+
+      - name: Set up Node.js for npm audit
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run npm audit (JS dependency scan)
+        working-directory: ./frontend
+        # HIGH vulns in next@14.x (GHSA-9g9p-9gw9-jx7f, GHSA-h25m-26qc-wcjf) require
+        # next@15.6+ which is not yet stable (only canary); tracked for separate upgrade PR.
+        # HIGH vulns in eslint-config-next and jest-environment-jsdom are dev/build tooling
+        # only and are not present in the production runtime.
+        run: npm audit --audit-level=critical

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -94,6 +94,30 @@ async def log_requests(request: Request, call_next):
         logger.error(f"[{request_id}] Error: {str(e)}", exc_info=True)
         raise
 
+# Add security headers middleware
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+    if settings.ENVIRONMENT == "production":
+        response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+    return response
+
+MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
+
+@app.middleware("http")
+async def limit_body_size(request: Request, call_next):
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_BODY_SIZE:
+        return JSONResponse(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            content={"detail": "Request body too large"},
+        )
+    return await call_next(request)
+
 # Global exception handler - prevents information leakage
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
@@ -138,8 +162,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
 )
 
 # Add Prometheus metrics

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.109.0
+fastapi==0.125.0
 uvicorn[standard]==0.27.0
 sqlalchemy==2.0.25
 psycopg2-binary==2.9.9
@@ -10,9 +10,9 @@ python-dotenv==1.0.0
 httpx==0.26.0
 apscheduler==3.10.4
 pyjwt==2.8.0
-cryptography==42.0.0
+cryptography==46.0.5
 svix==1.85.0
-python-multipart==0.0.6
+python-multipart==0.0.22
 
 # Testing
 pytest==7.4.4

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -49,7 +49,7 @@ class TestOnboardingAuth:
             "name": "Test User",
             "idea_status": "not_set_on_idea",
         })
-        assert response.status_code == 403  # No token provided
+        assert response.status_code == 401  # No token provided
     
     def test_onboarding_extracts_clerk_id_from_token(self, client, test_user_data):
         """Test that clerk_id is extracted from JWT, not query params"""

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,40 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.accounts.dev https://*.clerk.accounts.dev",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https://images.clerk.dev https://img.clerk.com",
+      "font-src 'self'",
+      "connect-src 'self' https://*.clerk.accounts.dev https://api.resend.com",
+      "frame-src 'none'",
+    ].join("; "),
+  },
+]
+
 const nextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
+  output: "standalone",
   images: {
-    domains: ['images.clerk.dev', 'img.clerk.com'],
+    domains: ["images.clerk.dev", "img.clerk.com"],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ]
   },
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2260,13 +2260,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5284,13 +5284,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7627,9 +7627,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Add `add_security_headers` middleware to FastAPI: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` (production only)
- Add `limit_body_size` middleware (10 MB cap, returns 413)
- Restrict CORS from wildcard `["*"]` to explicit method and header lists
- Add CSP + all security headers to Next.js via `next.config.js` `headers()` export
- Upgrade 3 Python packages to eliminate all 12 known CVEs: `fastapi` 0.109.0->0.125.0 (starlette 0.35.1->0.50.0 transitively, fixes CVE-2024-47874 + CVE-2025-54121), `cryptography` 42.0.0->46.0.5 (6 CVEs), `python-multipart` 0.0.6->0.0.22 (2 CVEs)
- Add Bandit SAST step to `backend-lint-and-test` CI job
- Add `pip-audit` and `npm audit --audit-level=critical` steps to `security-scan` CI job
- Add `.github/dependabot.yml` for weekly automated dependency PRs (pip, npm, github-actions)
- Fix `test_onboarding_requires_token` assertion 403->401 to match FastAPI 0.125.0 `HTTPBearer` behavior (correct per RFC 7235)

## Test plan

- [x] `bandit -r app/ -ll` reports 0 issues
- [x] `pip-audit -r requirements.txt` reports no known vulnerabilities
- [x] `pytest`: 34 passed, 21 skipped, 0 failed
- [x] `tsc --noEmit`, `next lint`: clean
- [x] `npm audit --audit-level=critical`: exits 0 (no critical vulns)
- [x] `npm run test:coverage`: 9 passed
- [x] `npm run build`: 21 routes, compiled successfully
- [x] `docker build` backend image: success
- [x] `docker build` frontend image: success

## Notes on remaining npm HIGH vulns

`next@14.2.35` has two HIGH advisories (GHSA-9g9p-9gw9-jx7f, GHSA-h25m-26qc-wcjf) whose fix requires `next>=15.6.0`. As of this PR, `15.6.0` is only available in canary; no stable patch exists. The `glob`/`minimatch` HIGH issues are in `eslint-config-next` (dev/build tooling, not present in the production runtime). CI audits at `--audit-level=critical`; a follow-up PR should upgrade to Next.js 15 once `15.6.0` stable is released.