### PR TITLE
feat: accessibility audit and improvements (closes #22)

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -56,8 +56,9 @@ export default function DashboardPage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
+        <div className="text-center" role="status" aria-label="Loading">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+          <span className="sr-only">Loading...</span>
           <p className="mt-4 text-gray-600">Loading...</p>
         </div>
       </div>
@@ -88,7 +89,7 @@ export default function DashboardPage() {
             <h1 className="text-3xl font-semibold text-zinc-900 mb-8">Dashboard</h1>
 
             {user?.profile_status === "pending_review" && (
-              <div className="mb-8 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              <div role="alert" className="mb-8 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
                 <p className="font-medium">Your profile is pending review.</p>
                 <p className="mt-1">
                   We&apos;ll let you know once it&apos;s approved. In the meantime you can still review your profile and preferences on the{" "}
@@ -101,7 +102,7 @@ export default function DashboardPage() {
             )}
 
             {user?.profile_status === "approved" && !approvedBannerDismissed && (
-              <div className="mb-8 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+              <div role="status" className="mb-8 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
                 <div className="flex items-start justify-between gap-2">
                   <div>
                     <p className="font-medium">Your profile has been approved.</p>
@@ -125,7 +126,7 @@ export default function DashboardPage() {
             )}
 
             {user?.profile_status === "rejected" && (
-              <div className="mb-8 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+              <div role="alert" className="mb-8 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
                 <p className="font-medium">Your profile was not approved yet.</p>
                 <p className="mt-1">
                   Please review and update your profile on the{" "}
@@ -142,7 +143,7 @@ export default function DashboardPage() {
               <div className="bg-white border border-zinc-200 rounded-lg p-6">
                 <div className="flex items-start gap-4">
                   <div className="w-12 h-12 bg-zinc-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <svg className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg aria-hidden="true" className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>
                   </div>
@@ -163,7 +164,7 @@ export default function DashboardPage() {
               <div className="bg-white border border-zinc-200 rounded-lg p-6">
                 <div className="flex items-start gap-4">
                   <div className="w-12 h-12 bg-zinc-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <svg className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg aria-hidden="true" className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
                     </svg>
                   </div>
@@ -184,7 +185,7 @@ export default function DashboardPage() {
               <div className="bg-white border border-zinc-200 rounded-lg p-6">
                 <div className="flex items-start gap-4">
                   <div className="w-12 h-12 bg-zinc-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <svg className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg aria-hidden="true" className="w-6 h-6 text-zinc-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                     </svg>
                   </div>

--- a/frontend/app/discover/page.tsx
+++ b/frontend/app/discover/page.tsx
@@ -130,8 +130,9 @@ export default function DiscoverPage() {
     return (
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status" aria-label="Loading">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading profiles...</p>
           </div>
         </div>
@@ -322,11 +323,11 @@ export default function DiscoverPage() {
                   className="px-6 py-3 border border-zinc-300 text-zinc-700 font-medium rounded-lg hover:bg-zinc-50 transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
                   {savedProfiles.has(currentProfile.id) ? (
-                    <svg className="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
+                    <svg aria-hidden="true" className="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
                       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                     </svg>
                   ) : (
-                    <svg className="w-5 h-5 text-zinc-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
+                    <svg aria-hidden="true" className="w-5 h-5 text-zinc-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
                       <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                     </svg>
                   )}
@@ -367,14 +368,18 @@ export default function DiscoverPage() {
       {/* Invite Modal */}
       {showInviteModal && currentProfile && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-lg w-full p-6">
-            <h3 className="text-xl font-semibold text-zinc-900 mb-4">
+          <div role="dialog" aria-modal="true" aria-labelledby="invite-modal-title" className="bg-white rounded-lg max-w-lg w-full p-6">
+            <h3 id="invite-modal-title" className="text-xl font-semibold text-zinc-900 mb-4">
               Invite {currentProfile.name} to connect
             </h3>
             <p className="text-sm text-zinc-600 mb-4">
               Write a message explaining why you&apos;d like to connect (optional).
             </p>
+            <label htmlFor="invite-message" className="sr-only">
+              Message to {currentProfile.name}
+            </label>
             <textarea
+              id="invite-message"
               value={inviteMessage}
               onChange={(e) => setInviteMessage(e.target.value)}
               placeholder="Hi! I'm interested in connecting because... (optional)"
@@ -382,7 +387,7 @@ export default function DiscoverPage() {
               rows={6}
               maxLength={500}
             />
-            <p className="text-xs text-zinc-500 mt-2">
+            <p aria-live="polite" aria-atomic="true" className="text-xs text-zinc-500 mt-2">
               {inviteMessage.length}/500 characters
             </p>
             <div className="flex gap-3 mt-6">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -112,3 +112,20 @@
 .safe-area-bottom {
   padding-bottom: env(safe-area-inset-bottom);
 }
+
+/* Accessibility: ensure focus ring is always visible */
+:focus-visible {
+  outline: 2px solid #18181b;
+  outline-offset: 2px;
+}
+
+/* Accessibility: reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/frontend/app/inbox/[match_id]/page.tsx
+++ b/frontend/app/inbox/[match_id]/page.tsx
@@ -130,8 +130,9 @@ export default function ConversationPage() {
     return (
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status" aria-label="Loading">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading...</p>
           </div>
         </div>
@@ -169,7 +170,7 @@ export default function ConversationPage() {
               href="/inbox"
               className="text-zinc-600 hover:text-zinc-900"
             >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg aria-hidden="true" className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
             </Link>
@@ -205,7 +206,7 @@ export default function ConversationPage() {
         </div>
 
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto bg-gray-50 p-4">
+        <div role="log" aria-label="Conversation messages" aria-live="polite" className="flex-1 overflow-y-auto bg-gray-50 p-4">
           <div className="max-w-4xl mx-auto space-y-4">
             {messages.length === 0 ? (
               <div className="text-center py-12">
@@ -252,6 +253,7 @@ export default function ConversationPage() {
                 value={newMessage}
                 onChange={(e) => setNewMessage(e.target.value)}
                 placeholder="Type a message..."
+                aria-label="Type a message"
                 className="flex-1 px-4 py-2 border border-zinc-300 rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-zinc-900 transition-colors"
                 disabled={sending}
               />

--- a/frontend/app/inbox/page.tsx
+++ b/frontend/app/inbox/page.tsx
@@ -100,8 +100,9 @@ export default function InboxPage() {
     return (
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status" aria-label="Loading">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading...</p>
           </div>
         </div>
@@ -138,6 +139,7 @@ export default function InboxPage() {
           {!hasAnyContent ? (
             <div className="bg-white border border-zinc-200 rounded-lg p-12 text-center">
               <svg
+                aria-hidden="true"
                 className="w-16 h-16 text-zinc-400 mx-auto mb-4"
                 fill="none"
                 stroke="currentColor"
@@ -277,7 +279,10 @@ export default function InboxPage() {
                           <div className="flex items-center gap-2">
                             <h3 className="font-semibold text-zinc-900">{conv.other_user.name}</h3>
                             {conv.unread_count > 0 && (
-                              <span className="px-2 py-0.5 bg-green-600 text-white text-xs font-medium rounded-full">
+                              <span
+                                aria-label={`${conv.unread_count} unread message${conv.unread_count !== 1 ? "s" : ""}`}
+                                className="px-2 py-0.5 bg-green-600 text-white text-xs font-medium rounded-full"
+                              >
                                 {conv.unread_count}
                               </span>
                             )}

--- a/frontend/app/onboarding/basics/page.tsx
+++ b/frontend/app/onboarding/basics/page.tsx
@@ -87,12 +87,13 @@ export default function BasicsPage() {
   }
 
   if (loading) {
-    return <div className="animate-pulse h-64 bg-gray-100 rounded-lg" />
+    return <div aria-busy="true" className="animate-pulse h-64 bg-gray-100 rounded-lg" />
   }
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <h1 className="text-2xl font-bold text-zinc-900 mb-6">Basics</h1>
+      <p className="text-sm text-zinc-500 mb-6">Fields marked with * are required</p>
 
       <div className="space-y-4">
         <div>
@@ -123,6 +124,7 @@ export default function BasicsPage() {
             onChange={(e) => update("linkedin_url", e.target.value)}
             className="w-full px-4 py-2 border border-gray-300 rounded-lg"
             placeholder="https://linkedin.com/in/yourprofile"
+            aria-required="true"
           />
         </div>
         <div>
@@ -151,6 +153,7 @@ export default function BasicsPage() {
           minLength={50}
           maxLength={2000}
           placeholder="A paragraph or two about your background and skills"
+          required
         />
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Gender</label>

--- a/frontend/app/onboarding/preferences/page.tsx
+++ b/frontend/app/onboarding/preferences/page.tsx
@@ -78,6 +78,7 @@ export default function PreferencesPage() {
           onChange={(v) => update("looking_for_description", v)}
           minLength={50}
           maxLength={1000}
+          required
         />
 
         <div>
@@ -98,8 +99,8 @@ export default function PreferencesPage() {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Want a technical co-founder?</label>
+        <fieldset>
+          <legend className="text-sm font-medium text-gray-700 mb-2">Want a technical co-founder?</legend>
           <div className="flex gap-4 mb-2">
             <label className="flex items-center gap-2">
               <input type="radio" name="pref_technical" checked={form.pref_technical === true} onChange={() => update("pref_technical", true)} className="rounded border-gray-300" />
@@ -115,12 +116,13 @@ export default function PreferencesPage() {
             </label>
           </div>
           <ImportanceSelector value={form.pref_technical_importance} onChange={(v) => update("pref_technical_importance", v)} />
-        </div>
+        </fieldset>
 
-        <div>
+        <fieldset>
+          <legend className="text-sm font-medium text-gray-700 mb-1">Timing preference</legend>
           <label className="flex items-center gap-2 mb-1">
             <input type="checkbox" checked={form.pref_match_timing} onChange={(e) => update("pref_match_timing", e.target.checked)} className="rounded border-gray-300" />
-            <span className="text-sm font-medium text-gray-700">Want co-founder who matches my timing</span>
+            <span className="text-sm text-gray-700">Want co-founder who matches my timing</span>
           </label>
           {form.pref_match_timing && (
             <div className="ml-6 mt-2">
@@ -128,7 +130,7 @@ export default function PreferencesPage() {
               <ImportanceSelector value={form.pref_timing_importance} onChange={(v) => update("pref_timing_importance", v)} />
             </div>
           )}
-        </div>
+        </fieldset>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Location preference</label>
@@ -193,10 +195,11 @@ export default function PreferencesPage() {
         />
         <ImportanceSelector value={form.pref_areas_importance} onChange={(v) => update("pref_areas_importance", v)} />
 
-        <div>
+        <fieldset>
+          <legend className="text-sm font-medium text-gray-700 mb-1">Shared interests</legend>
           <label className="flex items-center gap-2 mb-1">
             <input type="checkbox" checked={form.pref_shared_interests} onChange={(e) => update("pref_shared_interests", e.target.checked)} className="rounded border-gray-300" />
-            <span className="text-sm font-medium text-gray-700">Match only with shared topics</span>
+            <span className="text-sm text-gray-700">Match only with shared topics</span>
           </label>
           {form.pref_shared_interests && (
             <div className="ml-6 mt-2">
@@ -204,7 +207,7 @@ export default function PreferencesPage() {
               <ImportanceSelector value={form.pref_interests_importance} onChange={(v) => update("pref_interests_importance", v)} />
             </div>
           )}
-        </div>
+        </fieldset>
 
         <label className="flex items-center gap-2">
           <input type="checkbox" checked={form.alert_on_new_matches} onChange={(e) => update("alert_on_new_matches", e.target.checked)} className="rounded border-gray-300" />

--- a/frontend/app/profile/[id]/page.tsx
+++ b/frontend/app/profile/[id]/page.tsx
@@ -114,8 +114,9 @@ export default function ProfileDetailPage() {
     return (
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading profile...</p>
           </div>
         </div>
@@ -149,7 +150,7 @@ export default function ProfileDetailPage() {
             href="/discover"
             className="inline-flex items-center gap-2 text-zinc-600 hover:text-zinc-900 mb-6"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back to Discover
@@ -252,11 +253,11 @@ export default function ProfileDetailPage() {
                 className="flex-1 px-6 py-3 bg-zinc-900 text-white font-medium rounded-lg hover:bg-zinc-800 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {isSaved ? (
-                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                  <svg aria-hidden="true" className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                     <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                   </svg>
                 ) : (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
+                  <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
                     <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                   </svg>
                 )}
@@ -273,15 +274,16 @@ export default function ProfileDetailPage() {
               </button>
             </div>
             {reportOpen && (
-              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-labelledby="report-modal-title">
                 <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-                  <h3 className="text-lg font-semibold text-zinc-900 mb-4">Report profile</h3>
+                  <h3 id="report-modal-title" className="text-lg font-semibold text-zinc-900 mb-4">Report profile</h3>
                   {reportDone ? (
                     <p className="text-zinc-700">Thank you. Your report has been submitted and will be reviewed.</p>
                   ) : (
                     <>
-                      <label className="block text-sm font-medium text-zinc-700 mb-2">Reason</label>
+                      <label htmlFor="report-reason" className="block text-sm font-medium text-zinc-700 mb-2">Reason</label>
                       <select
+                        id="report-reason"
                         value={reportType}
                         onChange={(e) => setReportType(e.target.value)}
                         className="w-full border border-zinc-300 rounded-lg px-3 py-2 text-zinc-900 mb-4"
@@ -290,8 +292,9 @@ export default function ProfileDetailPage() {
                           <option key={t.value} value={t.value}>{t.label}</option>
                         ))}
                       </select>
-                      <label className="block text-sm font-medium text-zinc-700 mb-2">Details (min 10 characters)</label>
+                      <label htmlFor="report-details" className="block text-sm font-medium text-zinc-700 mb-2">Details (min 10 characters)</label>
                       <textarea
+                        id="report-details"
                         value={reportDesc}
                         onChange={(e) => setReportDesc(e.target.value)}
                         placeholder="Describe what happened..."

--- a/frontend/app/revisit/page.tsx
+++ b/frontend/app/revisit/page.tsx
@@ -88,8 +88,9 @@ function RevisitPageContent() {
     return (
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status" aria-label="Loading">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading profiles...</p>
           </div>
         </div>
@@ -105,8 +106,10 @@ function RevisitPageContent() {
 
           {/* Tabs */}
           <div className="border-b border-zinc-200 mb-6">
-            <div className="flex gap-8">
+            <div role="tablist" className="flex gap-8">
               <button
+                role="tab"
+                aria-selected={activeTab === "saved"}
                 onClick={() => setActiveTab("saved")}
                 className={`pb-4 px-1 font-medium transition-colors ${
                   activeTab === "saved"
@@ -117,6 +120,8 @@ function RevisitPageContent() {
                 Saved Profiles ({savedProfiles.length})
               </button>
               <button
+                role="tab"
+                aria-selected={activeTab === "skipped"}
                 onClick={() => setActiveTab("skipped")}
                 className={`pb-4 px-1 font-medium transition-colors ${
                   activeTab === "skipped"
@@ -130,6 +135,7 @@ function RevisitPageContent() {
           </div>
 
           {/* Profile List */}
+          <div role="tabpanel">
           {currentProfiles.length === 0 ? (
             <div className="bg-white border border-zinc-200 rounded-lg p-12 text-center">
               <p className="text-zinc-600 text-lg mb-4">
@@ -208,16 +214,16 @@ function RevisitPageContent() {
                       className="px-4 py-2 border border-zinc-300 text-zinc-700 font-medium rounded-lg hover:bg-zinc-50 transition-colors disabled:opacity-50"
                     >
                       {actionLoading === profile.id ? (
-                        <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <svg aria-hidden="true" className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
                           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                         </svg>
                       ) : activeTab === "saved" ? (
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
+                        <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 20 20">
                           <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
                         </svg>
                       ) : (
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                        <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                         </svg>
                       )}
@@ -227,6 +233,7 @@ function RevisitPageContent() {
               ))}
             </div>
           )}
+          </div>
         </div>
       </div>
     </AppShell>
@@ -238,8 +245,9 @@ export default function RevisitPage() {
     <Suspense fallback={
       <AppShell>
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
+          <div className="text-center" role="status" aria-label="Loading">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-zinc-900 mx-auto"></div>
+            <span className="sr-only">Loading...</span>
             <p className="mt-4 text-gray-600">Loading...</p>
           </div>
         </div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -54,6 +54,7 @@ function Toggle({
         type="button"
         role="switch"
         aria-checked={checked}
+        aria-label={label}
         onClick={() => onChange(!checked)}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 ${
           checked ? "bg-zinc-900" : "bg-zinc-200"
@@ -259,10 +260,10 @@ export default function SettingsPage() {
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">{error}</div>
+        <div role="alert" aria-live="polite" className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">{error}</div>
       )}
       {successMsg && (
-        <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-3 text-sm text-green-700">
+        <div role="status" aria-live="polite" className="bg-green-50 border border-green-200 rounded-lg px-4 py-3 text-sm text-green-700">
           {successMsg}
         </div>
       )}
@@ -324,6 +325,7 @@ export default function SettingsPage() {
               <button
                 key={f}
                 type="button"
+                aria-pressed={settings.notifications.frequency === f}
                 onClick={() =>
                   setSettings((s) => ({ ...s, notifications: { ...s.notifications, frequency: f } }))
                 }
@@ -350,6 +352,7 @@ export default function SettingsPage() {
               <button
                 key={v}
                 type="button"
+                aria-pressed={settings.privacy.profile_visibility === v}
                 onClick={() =>
                   setSettings((s) => ({ ...s, privacy: { ...s.privacy, profile_visibility: v } }))
                 }
@@ -399,6 +402,7 @@ export default function SettingsPage() {
               <button
                 key={v}
                 type="button"
+                aria-pressed={settings.communication.who_can_send_intros === v}
                 onClick={() =>
                   setSettings((s) => ({ ...s, communication: { ...s.communication, who_can_send_intros: v } }))
                 }
@@ -505,14 +509,17 @@ export default function SettingsPage() {
           </div>
           {showDeleteConfirm && (
             <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg space-y-3">
-              <p className="text-sm text-red-700 font-medium">
+              <p id="delete-confirm-warning" className="text-sm text-red-700 font-medium">
                 Type <span className="font-bold">delete my account</span> to confirm.
               </p>
+              <label htmlFor="delete-confirm" className="sr-only">Type DELETE to confirm</label>
               <input
+                id="delete-confirm"
                 type="text"
                 value={deletePhrase}
                 onChange={(e) => setDeletePhrase(e.target.value)}
                 placeholder="delete my account"
+                aria-describedby="delete-confirm-warning"
                 className="w-full px-3 py-2 text-sm border border-red-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-400"
               />
               <div className="flex gap-2">

--- a/frontend/components/forms/MultiSelect.tsx
+++ b/frontend/components/forms/MultiSelect.tsx
@@ -26,6 +26,8 @@ export function MultiSelect({
   className = "",
 }: MultiSelectProps) {
   const id = useId()
+  const slugId = label ? label.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "") : id
+  const errorId = `${slugId}-error`
 
   const toggle = (v: string) => {
     if (value.includes(v)) {
@@ -36,7 +38,7 @@ export function MultiSelect({
   }
 
   return (
-    <div className={className}>
+    <div className={className} aria-invalid={!!error} aria-describedby={error ? errorId : undefined}>
       {label && (
         <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-2">
           {label}
@@ -45,7 +47,11 @@ export function MultiSelect({
           )}
         </label>
       )}
-      <div className="space-y-2" role="group" aria-labelledby={label ? id : undefined}>
+      <div
+        className="space-y-2"
+        role="group"
+        aria-labelledby={label ? id : undefined}
+      >
         {(options as Option[]).map((opt) => (
           <label key={opt.value} className="flex items-center gap-2 cursor-pointer">
             <input
@@ -59,7 +65,7 @@ export function MultiSelect({
           </label>
         ))}
       </div>
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+      {error && <p id={errorId} className="mt-1 text-sm text-red-600">{error}</p>}
     </div>
   )
 }

--- a/frontend/components/forms/RichTextArea.tsx
+++ b/frontend/components/forms/RichTextArea.tsx
@@ -13,6 +13,7 @@ type RichTextAreaProps = {
   maxLength?: number
   rows?: number
   className?: string
+  required?: boolean
 }
 
 export function RichTextArea({
@@ -26,8 +27,12 @@ export function RichTextArea({
   maxLength = 2000,
   rows = 4,
   className = "",
+  required,
 }: RichTextAreaProps) {
   const id = useId()
+  const slugId = label ? label.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "") : id
+  const errorId = `${slugId}-error`
+  const countId = `${slugId}-count`
   return (
     <div className={className}>
       {label && (
@@ -44,11 +49,14 @@ export function RichTextArea({
         placeholder={placeholder}
         rows={rows}
         maxLength={maxLength}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : countId}
+        aria-required={required}
         className={`w-full px-4 py-2 border rounded-lg ${error ? "border-red-500" : "border-gray-300"} focus:ring-2 focus:ring-zinc-900 focus:border-transparent`}
       />
       <p className="mt-1 text-sm text-gray-500 text-right">
-        {error && <span className="text-red-600 float-left">{error}</span>}
-        {value.length} / {maxLength}
+        {error && <span id={errorId} role="alert" className="text-red-600 float-left">{error}</span>}
+        <span id={countId} aria-live="polite" aria-atomic="true">{value.length} / {maxLength}</span>
       </p>
     </div>
   )

--- a/frontend/components/forms/TagInput.tsx
+++ b/frontend/components/forms/TagInput.tsx
@@ -24,6 +24,8 @@ export function TagInput({
   className = "",
 }: TagInputProps) {
   const id = useId()
+  const slugId = label ? label.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "") : id
+  const listboxId = `${slugId}-listbox`
   const [open, setOpen] = useState(false)
   const optList = options as string[]
 
@@ -68,17 +70,25 @@ export function TagInput({
         <button
           type="button"
           id={id}
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-controls={listboxId}
           onClick={() => setOpen(!open)}
           className="w-full px-4 py-2 border border-gray-300 rounded-lg text-left bg-white focus:ring-2 focus:ring-zinc-900"
         >
           {placeholder}
         </button>
         {open && (
-          <ul className="absolute z-10 mt-1 w-full max-h-48 overflow-auto border border-gray-200 rounded-lg bg-white shadow-lg">
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="absolute z-10 mt-1 w-full max-h-48 overflow-auto border border-gray-200 rounded-lg bg-white shadow-lg"
+          >
             {optList
               .filter((o) => !value.includes(o))
               .map((o) => (
-                <li key={o}>
+                <li key={o} role="option" aria-selected={value.includes(o)}>
                   <button
                     type="button"
                     className="w-full px-4 py-2 text-left hover:bg-gray-100"

--- a/frontend/components/layout/AppShell.tsx
+++ b/frontend/components/layout/AppShell.tsx
@@ -9,15 +9,24 @@ export function AppShell({
 }) {
   return (
     <div className="min-h-screen bg-gray-50 flex">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-zinc-900 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium"
+      >
+        Skip to main content
+      </a>
       <Sidebar />
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 min-w-0">
         {/* Spacer for mobile fixed top header */}
-        <div className="h-14 md:hidden shrink-0" />
-        <div className="flex-1 min-w-0">
+        <div className="h-14 md:hidden" />
+        <div
+          id="main-content"
+          className="flex flex-col min-h-[calc(100vh-3.5rem-4rem)] md:min-h-screen"
+        >
           {children}
         </div>
         {/* Spacer for mobile fixed bottom nav */}
-        <div className="h-16 md:hidden shrink-0" />
+        <div className="h-16 md:hidden" />
       </div>
     </div>
   )

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -20,7 +20,7 @@ const navItems: NavItem[] = [
     label: "Dashboard",
     href: "/dashboard",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
       </svg>
     ),
@@ -29,7 +29,7 @@ const navItems: NavItem[] = [
     label: "Discover",
     href: "/discover",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     ),
@@ -38,7 +38,7 @@ const navItems: NavItem[] = [
     label: "Revisit",
     href: "/revisit",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
       </svg>
     ),
@@ -48,7 +48,7 @@ const navItems: NavItem[] = [
     label: "Inbox",
     href: "/inbox",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
       </svg>
     ),
@@ -57,7 +57,7 @@ const navItems: NavItem[] = [
     label: "My Account",
     href: "/profile",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
       </svg>
     ),
@@ -67,7 +67,7 @@ const navItems: NavItem[] = [
     label: "Settings",
     href: "/settings",
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
@@ -78,7 +78,7 @@ const navItems: NavItem[] = [
     href: "/admin",
     adminOnly: true,
     icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
       </svg>
     ),
@@ -147,12 +147,15 @@ export function Sidebar() {
         </span>
         <span className="font-medium">{item.label}</span>
         {item.adminOnly && pendingReview > 0 && (
-          <span className="ml-auto min-w-[20px] h-5 px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-xs font-semibold">
+          <span
+            aria-label={`${pendingReview} pending reviews`}
+            className="ml-auto min-w-[20px] h-5 px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-xs font-semibold"
+          >
             {pendingReview > 99 ? "99+" : pendingReview}
           </span>
         )}
         {item.hasSubmenu && (
-          <svg className="w-4 h-4 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg aria-hidden="true" className="w-4 h-4 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
         )}
@@ -185,8 +188,10 @@ export function Sidebar() {
           onClick={() => setMobileOpen(true)}
           className="p-2 -ml-2 rounded-lg text-zinc-600 hover:bg-zinc-100 touch-manipulation"
           aria-label="Open navigation menu"
+          aria-expanded={mobileOpen}
+          aria-controls="mobile-drawer"
         >
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg aria-hidden="true" className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
@@ -204,7 +209,7 @@ export function Sidebar() {
             aria-hidden="true"
           />
           {/* Drawer panel */}
-          <aside className="relative w-72 max-w-[80vw] bg-white flex flex-col h-full shadow-xl">
+          <aside id="mobile-drawer" className="relative w-72 max-w-[80vw] bg-white flex flex-col h-full shadow-xl">
             <div className="p-5 border-b border-zinc-200 flex items-center justify-between">
               <h1 className="text-xl font-semibold text-zinc-900">CoFounder Match</h1>
               <button
@@ -212,7 +217,7 @@ export function Sidebar() {
                 className="p-2 rounded-lg text-zinc-500 hover:bg-zinc-100 touch-manipulation"
                 aria-label="Close menu"
               >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>


### PR DESCRIPTION
## Summary

Full WCAG 2.1 AA accessibility audit and implementation across the frontend, plus a layout scroll regression fix.

## Accessibility changes

**Navigation & layout**
- AppShell: skip-to-content link as first focusable element
- Sidebar: `aria-expanded` on hamburger button, `aria-controls`/`id` on drawer panel, `aria-hidden` on all decorative SVGs, `aria-label` on pending review badge

**Loading states** (all pages)
- All loading spinners: `role="status"` + `aria-label` + `<span className="sr-only">` text

**Dynamic regions**
- Alert banners: `role="alert"` for errors, `role="status"` for info
- Messages container: `role="log"` + `aria-live="polite"`
- Character counts: `aria-live="polite"` + `aria-atomic="true"`
- Settings success/error: `role="status"` / `role="alert"`

**Modals**
- Discover invite modal: `role="dialog"`, `aria-modal`, `aria-labelledby` linked to title id
- Profile report modal: `aria-labelledby` linked to heading id

**Tabs**
- Revisit page: `role="tablist"`, `role="tab"`, `aria-selected`, `role="tabpanel"`

**Forms**
- RichTextArea: `aria-invalid`, `aria-describedby`, `aria-required`, error id, live count id
- MultiSelect: `aria-invalid`, `aria-describedby`, error id
- TagInput: `aria-expanded`, `aria-haspopup="listbox"`, `role="listbox"`, `role="option"`, `aria-selected`
- Settings toggles: `aria-label` on `role="switch"` buttons
- Settings option buttons: `aria-pressed`
- Inbox: unread badge `aria-label` with count
- Profile: `htmlFor`/`id` associations on report form select and textarea
- Delete confirmation: label + `id` association
- Onboarding: `aria-required` on required fields, `fieldset`/`legend` for radio/checkbox groups, required fields explanation

**Global CSS**
- `:focus-visible` outline rule ensuring focus ring is always visible
- `prefers-reduced-motion` media query to respect user motion preferences

## Layout fix

Removed `flex flex-col` from the AppShell right-column wrapper. The previous structure created a height-constrained flex item (`flex-1` on `#main-content` inside a `flex-col` parent), which trapped page content inside a viewport-height box and prevented the body from scrolling. The content area now grows naturally and the page scrolls via the body as expected. `#main-content` keeps `flex flex-col` with a `min-h` so loading/empty centering states still work.

## CI

- typecheck: clean
- lint: no warnings or errors
- tests: 9/9 pass

Closes #22